### PR TITLE
Mark module as deprecated with the redis module moved to opsdroid core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+⚠️ DEPRECATED ⚠️ This connector is now built in to [opsdroid core](https://opsdroid.readthedocs.io/en/stable/database/redis). This repository only exists for backward compatibility and will be removed.
+
 # opsdroid database redis
 
 A database module for [opsdroid](https://github.com/opsdroid/opsdroid) to persist memory in a [redis database](https://redis.io/).


### PR DESCRIPTION
This should not me merged until [this PR in core](https://github.com/opsdroid/opsdroid/pull/682) is merged. This PR marks the module as deprecated in favor of using the functionality in opsdroid core.